### PR TITLE
Added text to Help explaining Debug can fill logs

### DIFF
--- a/locales/en-US/smartmeter.json
+++ b/locales/en-US/smartmeter.json
@@ -9,7 +9,7 @@
             "d0SignOnMessage": "SignIn-Message (D0)",
             "d0BaudrateChangeoverOverwrite": "Force Baudrate (D0)",
             "protocolSmlIgnoreInvalidCRC": "Ignore invalid CRC (Sml)",
-            "debugging": "Debugging"
+            "debugging": "Debugging (see 'Help' tab)"
         },
         "placeholder": {
             "requestInterval": "0"

--- a/smartmeter.html
+++ b/smartmeter.html
@@ -1,5 +1,6 @@
 <script type="text/x-red" data-help-name="smartmeter">
     <p>Node to provide data from smartmeters</p>
+    <span style="font-weight:bold">Debugging:</span> use this option judiciously as it will generate a lot of data and could fill up your local storage.
 </script>
 
 <script type="text/x-red" data-template-name="smartmeter">


### PR DESCRIPTION
Added text to say tyou should use 'Debug' judiciously as it will generate a lot of data and could fill up your local storage.
see issue https://github.com/coolchip/node-red-contrib-smartmeter/issues/35
and NR topic https://discourse.nodered.org/t/debug-node-store-somewhere-and-use-space-on-sd-card/59856/6