### PR TITLE
External trigger

### DIFF
--- a/smartmeter.html
+++ b/smartmeter.html
@@ -101,7 +101,7 @@
                 required: false
             }
         },
-        inputs: 0,
+        inputs: 1,
         outputs: 1,
         icon: "gauge.png",
         label: function () {

--- a/smartmeter.js
+++ b/smartmeter.js
@@ -42,9 +42,11 @@ module.exports = function (RED) {
 			}
 
 			var smTransport = smartmeterObis.init(options, sendData);
+			var firstRun = true;
 			
 			if (config.requestInterval >= 0 ) {
 				smTransport.process();
+				firstRun = false;
 			}
 
 			node.on('close', function () {
@@ -52,7 +54,7 @@ module.exports = function (RED) {
 			});
 			
 			node.on('input', function() {
-				if (!smTransport.protocol.isProcessComplete()) {
+				if (!firstRun && !smTransport.protocol.isProcessComplete()) {
                 			node.warn("Previous process hasn't finished yet");
                 			return;
             			}
@@ -60,6 +62,7 @@ module.exports = function (RED) {
 				if (config.requestInterval < 0 ) {
 					smTransport = smartmeterObis.init(options, sendData);
 				}
+				firstRun = false;
 			});
 		}
 	}

--- a/smartmeter.js
+++ b/smartmeter.js
@@ -41,10 +41,9 @@ module.exports = function (RED) {
 				node.send(msg);
 			}
 
-			var smTransport;
+			var smTransport = smartmeterObis.init(options, sendData);
 			
 			if (config.requestInterval >= 0 ) {
-				smTransport = smartmeterObis.init(options, sendData);
 				smTransport.process();
 			}
 
@@ -57,10 +56,10 @@ module.exports = function (RED) {
                 			node.warn("Previous process hasn't finished yet");
                 			return;
             			}
-				if (config.requestInterval == -1 ) {
+				smTransport.process();
+				if (config.requestInterval < 0 ) {
 					smTransport = smartmeterObis.init(options, sendData);
 				}
-				smTransport.process();
 			});
 		}
 	}

--- a/smartmeter.js
+++ b/smartmeter.js
@@ -54,7 +54,7 @@ module.exports = function (RED) {
                 			return;
             			}
 				smTransport.process();
-			}
+			});
 		}
 	}
 	RED.nodes.registerType('smartmeter', SmartmeterNode);

--- a/smartmeter.js
+++ b/smartmeter.js
@@ -57,7 +57,7 @@ module.exports = function (RED) {
                 			node.warn("Previous process hasn't finished yet");
                 			return;
             			}
-				if (config.requestInterval < 0 ) {
+				if (config.requestInterval == -1 ) {
 					smTransport = smartmeterObis.init(options, sendData);
 				}
 				smTransport.process();

--- a/smartmeter.js
+++ b/smartmeter.js
@@ -41,19 +41,23 @@ module.exports = function (RED) {
 				node.send(msg);
 			}
 
-			var smTransport = smartmeterObis.init(options, sendData);
-			smTransport.process();
+			var smTransport;
+			
+			if (config.requestInterval >= 0 ) {
+				smTransport = smartmeterObis.init(options, sendData);
+				smTransport.process();
+			}
 
 			node.on('close', function () {
 				smTransport.stop();
 			});
 			
-			node.on('input', function(msg) {
+			node.on('input', function() {
 				if (!smTransport.protocol.isProcessComplete()) {
                 			node.warn("Previous process hasn't finished yet");
                 			return;
             			}
-				if (config.requestInterval == -1 ) {
+				if (config.requestInterval < 0 ) {
 					smTransport = smartmeterObis.init(options, sendData);
 				}
 				smTransport.process();

--- a/smartmeter.js
+++ b/smartmeter.js
@@ -53,6 +53,9 @@ module.exports = function (RED) {
                 			node.warn("Previous process hasn't finished yet");
                 			return;
             			}
+				if (config.requestInterval == -1 ) {
+					smTransport = smartmeterObis.init(options, sendData);
+				}
 				smTransport.process();
 			});
 		}

--- a/smartmeter.js
+++ b/smartmeter.js
@@ -47,6 +47,14 @@ module.exports = function (RED) {
 			node.on('close', function () {
 				smTransport.stop();
 			});
+			
+			node.on('input', function(msg) {
+				if (!smTransport.protocol.isProcessComplete()) {
+                			node.warn("Previous process hasn't finished yet");
+                			return;
+            			}
+				smTransport.process();
+			}
 		}
 	}
 	RED.nodes.registerType('smartmeter', SmartmeterNode);

--- a/smartmeter.js
+++ b/smartmeter.js
@@ -61,8 +61,8 @@ module.exports = function (RED) {
 				smTransport.process();
 				if (config.requestInterval < 0 ) {
 					smTransport = smartmeterObis.init(options, sendData);
+					firstRun = true;
 				}
-				firstRun = false;
 			});
 		}
 	}


### PR DESCRIPTION
Hello,

I added an input which allows triggering a request manually.
Interval can still be set and will work as usual, however sending random data in the input will trigger a new request (and reset the interval).
If interval is set to -1, polling is only driven by the input without initial polling. [smartmeter-obis](https://github.com/Apollon77/smartmeter-obis) stops the transport when interval is set to -1, so it is mandatory to reinitialize it. Maybe there are better ways to proceed but so far this is the best I could do. That would certainly imply modifying this library.

Regards,

Yanik